### PR TITLE
I-21: Rename fluent-compilation-buffer before invoking compile

### DIFF
--- a/fluent-mode.el
+++ b/fluent-mode.el
@@ -297,6 +297,7 @@ The default value is the current `fluent-command'.")
         (pre-existing-compilation-buffer
          (rename-that-buffer "*compilation*" "tmp")))
     (fluent-message "compiling: '%s'" full-command)
+    (rename-that-buffer fluent-compilation-buffer-name "*compilation*")
     (compile full-command)
     (rename-that-buffer
      "*compilation*" fluent-compilation-buffer-name


### PR DESCRIPTION
    - Rename fluent-compilation-buffer to *compilation* before
      invoking compile command in order to make compile to be executed
      in the same buffer.